### PR TITLE
feat: add agency matcher package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.DS_Store
+.env
+.venv
+.idea/
+.mypy_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # dgs-agency-matcher
-A Python package and Streamlit app for semantically matching Department of General Services (DGS) agency names to a clean, canonical list using fuzzy, TF‑IDF, and heuristic-based matching.
+
+A reusable Python package and Streamlit application for matching messy
+Department of General Services (DGS) agency names to a canonical list.
+The library combines light-weight text normalisation, alias expansion,
+TF‑IDF / RapidFuzz matching and human-style heuristics.
+
+## Installation
+
+```bash
+pip install .
+```
+
+## Command line usage
+
+The pipeline can be executed directly as a module. It expects an input CSV
+with an `agency` column and a text file containing candidate agency names.
+
+```bash
+python -m dgs_matcher.pipeline agencies.csv candidates.txt --output results.xlsx
+```
+
+## Streamlit application
+
+Run the interactive web app with:
+
+```bash
+streamlit run app.py
+```
+
+The UI lets you upload a CSV and paste candidate agencies, then download
+an Excel workbook with the matches.
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+pytest
+```
+
+## License
+
+This project is licensed under the terms of the MIT license.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,6 @@
+"""Streamlit entry point for the DGS agency matcher."""
+
+from dgs_matcher.ui import render
+
+if __name__ == "__main__":  # pragma: no cover - Streamlit handles running
+    render()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pandas==2.1.4
+scikit-learn==1.3.2
+rapidfuzz==3.5.2
+xlsxwriter==3.1.9
+streamlit==1.29.0
+pytest==8.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+"""Setup script for dgs-agency-matcher."""
+
+from pathlib import Path
+from setuptools import find_packages, setup
+
+README = (Path(__file__).parent / "README.md").read_text()
+
+setup(
+    name="dgs-agency-matcher",
+    version="0.1.0",
+    description="Match DGS agency names using TF-IDF and heuristic scoring",
+    long_description=README,
+    long_description_content_type="text/markdown",
+    author="",  # intentionally left blank
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
+    include_package_data=True,
+    install_requires=[
+        "pandas",
+        "scikit-learn",
+        "rapidfuzz",
+        "xlsxwriter",
+        "streamlit",
+    ],
+    python_requires=">=3.9",
+)

--- a/src/dgs_matcher/__init__.py
+++ b/src/dgs_matcher/__init__.py
@@ -1,0 +1,15 @@
+"""Top-level package for dgs_matcher.
+
+This package provides tools to normalize, alias, and match agency names
+for the California Department of General Services. It also exposes a
+Streamlit UI for manual exploration.
+"""
+
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("dgs-agency-matcher")
+except PackageNotFoundError:  # pragma: no cover - package not installed
+    __version__ = "0.0.0"
+
+__all__ = ["__version__"]

--- a/src/dgs_matcher/aliasing.py
+++ b/src/dgs_matcher/aliasing.py
@@ -1,0 +1,33 @@
+"""Alias handling for agency names.
+
+This module exposes a global alias mapping and helpers for expanding
+common short names to their canonical agency name.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+ALIAS_MAP: Dict[str, str] = {
+    "cal fire": "california department of forestry and fire protection",
+    "dmv": "department of motor vehicles",
+}
+
+
+def apply_alias(name: str) -> str:
+    """Return the canonical agency name for *name*.
+
+    Parameters
+    ----------
+    name:
+        Normalized agency string.
+
+    Returns
+    -------
+    str
+        Canonical form if a mapping exists, otherwise the input *name*.
+    """
+
+    return ALIAS_MAP.get(name, name)
+
+__all__ = ["apply_alias", "ALIAS_MAP"]

--- a/src/dgs_matcher/heuristics.py
+++ b/src/dgs_matcher/heuristics.py
@@ -1,0 +1,50 @@
+"""Heuristic scoring helpers.
+
+The functions here implement human-like heuristics used to adjust raw
+string similarity scores. They are intentionally lightweight and easy to
+extend in user projects.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+FALSE_FRIENDS = {"bank", "university"}
+
+
+def heuristic_score(candidate: str, query: str, anchors: Iterable[str] | None = None) -> float:
+    """Compute a heuristic score for *candidate*.
+
+    The score is meant to be added to a base similarity measure. It
+    rewards anchor coverage and state government keywords while penalising
+    known "false friend" terms.
+
+    Parameters
+    ----------
+    candidate:
+        Candidate agency name.
+    query:
+        Original query string; currently unused but reserved for future
+        rules.
+    anchors:
+        Optional iterable of anchor terms derived from the query.
+
+    Returns
+    -------
+    float
+        Heuristic bonus score, positive or negative.
+    """
+
+    score = 0.0
+    anchor_list = list(anchors or [])
+    if anchor_list:
+        score += sum(1 for a in anchor_list if a in candidate) / max(len(anchor_list), 1)
+    if any(word in candidate for word in ("state", "government")):
+        score += 0.1
+    if ".gov" in candidate:
+        score += 0.1
+    if any(ff in candidate for ff in FALSE_FRIENDS):
+        score -= 0.1
+    return score
+
+__all__ = ["heuristic_score", "FALSE_FRIENDS"]

--- a/src/dgs_matcher/matching.py
+++ b/src/dgs_matcher/matching.py
@@ -1,0 +1,61 @@
+"""Matching utilities for agency names.
+
+The main entry point is :func:`match_agency` which performs TF‑IDF based
+cosine similarity matching with optional anchor filtering. If the TF‑IDF
+step cannot produce a result, a RapidFuzz ratio match is used instead.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+
+from rapidfuzz import fuzz
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import linear_kernel
+
+
+def match_agency(query: str, candidates: Iterable[str], anchors: Iterable[str] | None = None) -> Tuple[str, float]:
+    """Match *query* against *candidates*.
+
+    Parameters
+    ----------
+    query:
+        Normalized agency name to match.
+    candidates:
+        Iterable of candidate agency names.
+    anchors:
+        Optional iterable of substrings that must appear in a candidate
+        for it to be considered. The filter is applied before TF‑IDF.
+
+    Returns
+    -------
+    tuple
+        A pair of ``(best_match, score)`` where *score* is a cosine
+        similarity in the range ``[0, 1]``. When RapidFuzz fallback is
+        used the score represents a ratio in ``[0, 1]``.
+    """
+
+    candidate_list: List[str] = list(candidates)
+    anchor_list = list(anchors or [])
+
+    filtered = (
+        [c for c in candidate_list if any(a in c for a in anchor_list)]
+        if anchor_list
+        else candidate_list
+    )
+    if not filtered:
+        filtered = candidate_list
+
+    if filtered:
+        vectorizer = TfidfVectorizer(analyzer="char", ngram_range=(3, 5))
+        tfidf = vectorizer.fit_transform(filtered + [query])
+        cosine_sim = linear_kernel(tfidf[-1], tfidf[:-1]).flatten()
+        if cosine_sim.size:
+            best_index = int(cosine_sim.argmax())
+            return filtered[best_index], float(cosine_sim[best_index])
+
+    # RapidFuzz fallback
+    best = max((fuzz.ratio(query, c) / 100.0, c) for c in candidate_list)
+    return best[1], float(best[0])
+
+__all__ = ["match_agency"]

--- a/src/dgs_matcher/normalize.py
+++ b/src/dgs_matcher/normalize.py
@@ -1,0 +1,64 @@
+"""Text normalization utilities.
+
+Functions in this module perform lightweight cleanup on free-text agency
+names so they can be compared semantically. Normalization is intentionally
+simple to keep the package dependency-light and easy to reason about.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict
+
+# basic abbreviation map used during normalization
+ABBREVIATIONS: Dict[str, str] = {
+    "dept": "department",
+    "dept.": "department",
+    "ca": "california",
+}
+
+_punct_re = re.compile(r"[\.,;:!\-_/\\]")
+
+
+def expand_abbreviations(text: str) -> str:
+    """Expand common abbreviations in *text*.
+
+    Parameters
+    ----------
+    text:
+        Input string to normalize.
+
+    Returns
+    -------
+    str
+        Text with abbreviations replaced using :data:`ABBREVIATIONS`.
+    """
+
+    words = [ABBREVIATIONS.get(w, w) for w in text.split()]
+    return " ".join(words)
+
+
+def normalize_text(text: str) -> str:
+    """Normalize *text* for matching.
+
+    The operation performs lowercasing, punctuation removal and
+    abbreviation expansion.
+
+    Parameters
+    ----------
+    text:
+        String to normalize.
+
+    Returns
+    -------
+    str
+        Normalized string suitable for fuzzy matching.
+    """
+
+    text = text.lower()
+    text = _punct_re.sub(" ", text)
+    text = expand_abbreviations(text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+__all__ = ["normalize_text", "expand_abbreviations", "ABBREVIATIONS"]

--- a/src/dgs_matcher/pipeline.py
+++ b/src/dgs_matcher/pipeline.py
@@ -1,0 +1,87 @@
+"""High level matching pipeline.
+
+This module glues together the building blocks from the package to offer a
+single function :func:`run_pipeline` which operates on a pandas
+:class:`~pandas.DataFrame` of agency names and returns the matched results.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+import pandas as pd
+
+from .aliasing import apply_alias
+from .heuristics import heuristic_score
+from .matching import match_agency
+from .normalize import normalize_text
+
+
+def run_pipeline(df: pd.DataFrame, candidates: Iterable[str], *, output_excel: Optional[Path] = None) -> pd.DataFrame:
+    """Run the full matching pipeline on *df*.
+
+    Parameters
+    ----------
+    df:
+        Input DataFrame expected to contain an ``"agency"`` column.
+    candidates:
+        Iterable of canonical agency names to match against.
+    output_excel:
+        Optional path; if provided the resulting DataFrame is also written
+        to this Excel file using :mod:`xlsxwriter`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing the original agency name, normalized form,
+        match and score.
+    """
+
+    processed = []
+    for original in df["agency"].drop_duplicates():
+        normalized = normalize_text(original)
+        aliased = apply_alias(normalized)
+        match, base_score = match_agency(aliased, candidates, anchors=aliased.split())
+        score = base_score + heuristic_score(match, aliased, anchors=aliased.split())
+        processed.append({
+            "original": original,
+            "normalized": aliased,
+            "match": match,
+            "score": score,
+        })
+
+    result = pd.DataFrame(processed)
+    if output_excel:
+        output_excel = Path(output_excel)
+        result.to_excel(output_excel, index=False)
+    return result
+
+__all__ = ["run_pipeline", "main"]
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point for the pipeline.
+
+    The command expects an input CSV file with an ``agency`` column and a
+    plain text file containing candidate agencies (one per line). The
+    results are written to ``output.xlsx`` unless another path is provided
+    via ``--output``.
+    """
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run DGS agency matching pipeline")
+    parser.add_argument("input_csv", help="CSV file with an 'agency' column")
+    parser.add_argument("candidates_txt", help="Text file of candidate agencies")
+    parser.add_argument("--output", default="output.xlsx", help="Excel file to write results to")
+    args = parser.parse_args(argv)
+
+    df = pd.read_csv(args.input_csv)
+    with open(args.candidates_txt) as fh:
+        candidates = [line.strip() for line in fh if line.strip()]
+    run_pipeline(df, candidates, output_excel=args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI invocation
+    main()

--- a/src/dgs_matcher/ui.py
+++ b/src/dgs_matcher/ui.py
@@ -1,0 +1,39 @@
+"""Streamlit user interface for the matcher.
+
+The :func:`render` function is imported by :mod:`app` and sets up a small
+interactive interface around :func:`dgs_matcher.pipeline.run_pipeline`.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import List
+
+import pandas as pd
+import streamlit as st
+
+from .pipeline import run_pipeline
+
+
+def render() -> None:
+    """Render the Streamlit interface."""
+
+    st.title("DGS Agency Matcher")
+    uploaded = st.file_uploader("Upload CSV of agencies", type="csv")
+    candidates_text = st.text_area("Candidate agencies (one per line)")
+
+    if uploaded and candidates_text:
+        df = pd.read_csv(uploaded)
+        candidates: List[str] = [c.strip() for c in candidates_text.splitlines() if c.strip()]
+        result = run_pipeline(df, candidates)
+        st.dataframe(result)
+        buf = BytesIO()
+        result.to_excel(buf, index=False)
+        st.download_button(
+            "Download results",
+            data=buf.getvalue(),
+            file_name="results.xlsx",
+            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+
+__all__ = ["render"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Pytest configuration to ensure the package is importable without installation."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,29 @@
+"""Tests for core matcher functionality."""
+
+from dgs_matcher.aliasing import apply_alias
+from dgs_matcher.matching import match_agency
+from dgs_matcher.normalize import normalize_text
+
+
+def test_normalize_text() -> None:
+    """Lowercasing, punctuation removal and abbreviation expansion."""
+
+    assert normalize_text("Dept. of CA!") == "department of california"
+
+
+def test_apply_alias() -> None:
+    """Alias expansion returns the canonical form."""
+
+    assert apply_alias("cal fire") == "california department of forestry and fire protection"
+
+
+def test_match_agency() -> None:
+    """TF‑IDF matching should prefer the exact candidate."""
+
+    candidates = [
+        "department of motor vehicles",
+        "california department of forestry and fire protection",
+    ]
+    match, score = match_agency("department of motor vehicles", candidates)
+    assert match == "department of motor vehicles"
+    assert score > 0.5


### PR DESCRIPTION
## Summary
- implement normalization, aliasing, matching, heuristic scoring, and pipeline modules
- add Streamlit UI and entrypoint
- provide tests, setup script, and requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a64dcb7750832d993b0bea73e3e96b